### PR TITLE
Fix an out-of-bounds read after a MOD sample swap at loop end

### DIFF
--- a/source/de/quippy/javamod/multimedia/mod/mixer/BasicModMixer.java
+++ b/source/de/quippy/javamod/multimedia/mod/mixer/BasicModMixer.java
@@ -2559,6 +2559,7 @@ public abstract class BasicModMixer
 						{
 							aktMemo.currentSamplePos = loopStart = sample.loopStart;
 							loopEnd = sample.loopStop;
+							loopLength = sample.loopLength;
 							inLoop = ModConstants.LOOP_ON;
 						}
 						else
@@ -2568,6 +2569,8 @@ public abstract class BasicModMixer
 							inLoop = 0;
 						}
 						aktMemo.currentTuningPos = aktMemo.prevSampleOffset = 0;
+						// The interpolation magic still belongs to the sample just left; recompute it for the new one
+						aktMemo.interpolationMagic = (inLoop==ModConstants.LOOP_ON)?sample.getLoopMagic(aktMemo.currentSamplePos):0;
 						continue;
 					}
 


### PR DESCRIPTION
When a ProTracker module names an instrument without a note, `mixChannelIntoBuffers` swaps the new sample in once the playing one reaches its loop end. The channel's `interpolationMagic` still holds the loop look-ahead offset of the sample that was just left, and the swap block `continue`s past the code at the bottom of the loop that would recompute it. If the new sample is shorter than that offset, the next `getInterpolatedSample()` reads beyond its buffer and the mixer dies:

```
java.lang.ArrayIndexOutOfBoundsException: Index 2136 out of bounds for length 1780
	at de.quippy.javamod.multimedia.mod.loader.instrument.Sample.getFIRInterpolated
	at de.quippy.javamod.multimedia.mod.loader.instrument.Sample.getInterpolatedSample
	at de.quippy.javamod.multimedia.mod.mixer.BasicModMixer.mixChannelIntoBuffers
	at de.quippy.javamod.multimedia.mod.mixer.BasicModMixer.mixIntoBuffer
```

I ran into it 27 seconds into "Iridium" by Misty & Daeron (Assembly 1996 music compo, `mod.iridium-comp`) with windowed FIR interpolation: channel 1 plays a 2264 byte sample looping 432-1808 with `interpolationMagic` at 520, then swaps in a 1620 byte sample with no loop. The position lands on 1619, the stale 520 is added, and the FIR taps read from 2136 in a buffer of 1780.

The fix recomputes `interpolationMagic` for the new sample before continuing. The loop branch also left `loopLength` at the old sample's value, so that is carried over as well. With the change the song plays through to the end, and a small test module that swaps a short non-looping sample in behind a long looping one no longer throws.
