### PR TITLE
Fix the sample index when reading OpenMPT sample cues

### DIFF
--- a/source/de/quippy/javamod/multimedia/mod/loader/Module.java
+++ b/source/de/quippy/javamod/multimedia/mod/loader/Module.java
@@ -1622,9 +1622,10 @@ public abstract class Module
 					{
 						final int cues = (size - 2)>>2; // should be MAX_CUES (or less)
 						final int sampleIndex = inputStream.readIntelWord();
-						if (sampleIndex>0 && sampleIndex<=getNSamples())
+						// the chunk counts samples from one, the container from zero
+						final Sample sample = (sampleIndex>0 && sampleIndex<=getNSamples())?getInstrumentContainer().getSample(sampleIndex-1):null;
+						if (sample!=null)
 						{
-							final Sample sample = getInstrumentContainer().getSample(sampleIndex);
 							// future versions of OMPT might have more than 9 cues...
 							final int[] theCues = new int[cues<Sample.MAX_CUES?Sample.MAX_CUES:cues];
 							int cue = 0;


### PR DESCRIPTION
The CUES chunk that OpenMPT writes into an MPTM file starts with the sample number, counted from one as sample numbers are everywhere in the format. `loadExtendedSongProperties` hands that number straight to `InstrumentsContainer.getSample()`, which counts from zero like the other callers expect (`ProTrackerMixer` does `getSample(sampleIndex-1)`, for example). Every cue list therefore ends up on the sample after the one it was saved for, and the list belonging to the last sample asks for a slot that does not exist, gets null and the loader dies:

```
java.lang.NullPointerException: Cannot invoke "de.quippy.javamod.multimedia.mod.loader.instrument.Sample.setCues(int[])" because "<local11>" is null
	at de.quippy.javamod.multimedia.mod.loader.Module.loadExtendedSongProperties
	at de.quippy.javamod.multimedia.mod.loader.tracker.ImpulseTrackerMod.loadModFileInternal
	at de.quippy.javamod.multimedia.mod.loader.Module.loadModFile
	at de.quippy.javamod.multimedia.mod.loader.ModuleFactory.getModuleFromStreamByID
	at de.quippy.javamod.multimedia.mod.loader.ModuleFactory.getInstance
```

I hit it with "late blossom" by cyclar2 from The Mod Archive (module 214361, saved with OpenMPT 1.32.06): eight samples, and the chunk for sample 8 finds nothing at index 8. Any MPTM whose last sample carries cues fails the same way; the others load, but with their cues shifted by one sample.

The fix looks the sample up at `sampleIndex-1` and skips the chunk when the slot is empty. With it the file loads and plays, and the cues sit on the samples they were saved with.

I think this is the right fix, but if you want to take a closer look, refer to the module above.
